### PR TITLE
feat: update VTEX order form UTM on successful add_to_cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v3.9.0
+----------
+* feat: add Extra field to ProductItem for interactive messages
+
 v3.8.0
 ----------
 * feat: add Extra field to ProductItem for interactive messages

--- a/pkg/vtex/client.go
+++ b/pkg/vtex/client.go
@@ -18,6 +18,7 @@ var safeSlugRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*$`)
 // IClient abstracts VTEX cart operations for testability.
 type IClient interface {
 	AddOrUpdateCartItem(ctx context.Context, vtexAccount, orderFormID, itemID, seller string) error
+	UpdateMarketingData(ctx context.Context, vtexAccount, orderFormID string) error
 }
 
 // OrderFormItem represents a single item in the VTEX order form.
@@ -48,6 +49,10 @@ type updateOrderItem struct {
 
 type updateItemsRequest struct {
 	OrderItems []updateOrderItem `json:"orderItems"`
+}
+
+type marketingDataRequest struct {
+	UTMSource string `json:"utmSource"`
 }
 
 // Client communicates with the VTEX Checkout API.
@@ -183,4 +188,18 @@ func (c *Client) AddOrUpdateCartItem(ctx context.Context, vtexAccount, orderForm
 	}
 
 	return c.addItem(ctx, vtexAccount, orderFormID, itemID, seller)
+}
+
+// UpdateMarketingData sets utmSource on the order form's marketing data attachment.
+func (c *Client) UpdateMarketingData(ctx context.Context, vtexAccount, orderFormID string) error {
+	if !safeSlugRe.MatchString(vtexAccount) {
+		return fmt.Errorf("vtex: invalid account name %q", vtexAccount)
+	}
+	if !safeSlugRe.MatchString(orderFormID) {
+		return fmt.Errorf("vtex: invalid order form ID %q", orderFormID)
+	}
+
+	reqURL := c.orderFormURL(vtexAccount, orderFormID) + "/attachments/marketingData"
+	body := marketingDataRequest{UTMSource: "weni-concierge"}
+	return c.postJSON(ctx, reqURL, body)
 }

--- a/pkg/vtex/client_mock.go
+++ b/pkg/vtex/client_mock.go
@@ -44,3 +44,17 @@ func (mr *MockIClientMockRecorder) AddOrUpdateCartItem(ctx, vtexAccount, orderFo
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOrUpdateCartItem", reflect.TypeOf((*MockIClient)(nil).AddOrUpdateCartItem), ctx, vtexAccount, orderFormID, itemID, seller)
 }
+
+// UpdateMarketingData mocks base method.
+func (m *MockIClient) UpdateMarketingData(ctx context.Context, vtexAccount, orderFormID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMarketingData", ctx, vtexAccount, orderFormID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateMarketingData indicates an expected call of UpdateMarketingData.
+func (mr *MockIClientMockRecorder) UpdateMarketingData(ctx, vtexAccount, orderFormID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMarketingData", reflect.TypeOf((*MockIClient)(nil).UpdateMarketingData), ctx, vtexAccount, orderFormID)
+}

--- a/pkg/vtex/client_test.go
+++ b/pkg/vtex/client_test.go
@@ -176,6 +176,67 @@ func TestAddOrUpdateCartItem_InvalidOrderFormID(t *testing.T) {
 	}
 }
 
+func TestUpdateMarketingData_Success(t *testing.T) {
+	var receivedBody marketingDataRequest
+	var receivedPath string
+	var receivedMethod string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedMethod = r.Method
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := newTestClient(server)
+	err := client.UpdateMarketingData(context.Background(), "teststore", "of123")
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodPost, receivedMethod)
+	assert.Equal(t, "/api/checkout/pub/orderForm/of123/attachments/marketingData", receivedPath)
+	assert.Equal(t, "weni-concierge", receivedBody.UTMSource)
+}
+
+func TestUpdateMarketingData_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"internal"}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server)
+	err := client.UpdateMarketingData(context.Background(), "teststore", "of123")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cart operation failed with status 500")
+}
+
+func TestUpdateMarketingData_InvalidInputs(t *testing.T) {
+	c := &Client{httpClient: &http.Client{}}
+
+	tests := []struct {
+		name        string
+		account     string
+		orderFormID string
+		errContains string
+	}{
+		{"invalid account", "evil.attacker.com", "of123", "invalid account name"},
+		{"empty account", "", "of123", "invalid account name"},
+		{"invalid order form", "teststore", "../../etc/passwd", "invalid order form ID"},
+		{"empty order form", "teststore", "", "invalid order form ID"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.UpdateMarketingData(context.Background(), tt.account, tt.orderFormID)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errContains)
+		})
+	}
+}
+
 func TestOrderFormURL_WithBaseURL(t *testing.T) {
 	c := &Client{baseURL: "http://localhost:8080"}
 	url := c.orderFormURL("teststore", "of123")

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -1059,6 +1059,18 @@ func (c *Client) AddToCart(payload OutgoingPayload, app *App) error {
 				}).WithError(sendErr).Error("failed to send cart_updated to client")
 			}
 		}
+
+		utmCtx, utmCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer utmCancel()
+
+		if utmErr := app.VTEXClient.UpdateMarketingData(utmCtx, vtexAccount, orderFormID); utmErr != nil {
+			log.WithFields(log.Fields{
+				"client_id":     c.ID,
+				"channel":       c.Channel,
+				"vtex_account":  vtexAccount,
+				"order_form_id": orderFormID,
+			}).WithError(utmErr).Warn("failed to update VTEX marketing data")
+		}
 	}()
 
 	return nil

--- a/pkg/websocket/client_test.go
+++ b/pkg/websocket/client_test.go
@@ -1781,6 +1781,7 @@ func TestAddToCart_HappyPath(t *testing.T) {
 
 	mockVTEX := vtex.NewMockIClient(ctrl)
 	mockVTEX.EXPECT().AddOrUpdateCartItem(gomock.Any(), "teststore", "of123", "prod_1", "seller_a").Return(nil)
+	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), "teststore", "of123").Return(nil)
 
 	client, ws, server := newTestClient(t)
 	defer server.Close()
@@ -1958,6 +1959,45 @@ func TestAddToCart_VTEXError(t *testing.T) {
 	assert.Equal(t, "prod_1", received.Data["item_id"])
 }
 
+func TestAddToCart_MarketingDataFailureDoesNotAffectCart(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockVTEX := vtex.NewMockIClient(ctrl)
+	mockVTEX.EXPECT().AddOrUpdateCartItem(gomock.Any(), "teststore", "of123", "prod_1", "seller_a").Return(nil)
+	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), "teststore", "of123").
+		Return(fmt.Errorf("vtex: cart operation failed with status 500"))
+
+	client, ws, server := newTestClient(t)
+	defer server.Close()
+	defer ws.Close()
+	client.ID = "test-client"
+	client.Callback = "http://example.com/callback"
+
+	app := vtexApp(t, mockVTEX)
+
+	err := client.AddToCart(OutgoingPayload{
+		Data: map[string]interface{}{
+			"vtex_account":  "teststore",
+			"order_form_id": "of123",
+			"item": map[string]interface{}{
+				"id":     "prod_1",
+				"seller": "seller_a",
+			},
+		},
+	}, app)
+	assert.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+
+	ws.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var received IncomingPayload
+	err = ws.ReadJSON(&received)
+	assert.NoError(t, err)
+	assert.Equal(t, "cart_updated", received.Type)
+	assert.Equal(t, "prod_1", received.Data["item_id"])
+}
+
 func TestAddToCartParsePayload(t *testing.T) {
 	rdb := redis.NewClient(&redis.Options{Addr: redisHost, DB: 3})
 	defer rdb.FlushAll(context.TODO())
@@ -1965,6 +2005,7 @@ func TestAddToCartParsePayload(t *testing.T) {
 
 	mockVTEX := vtex.NewMockIClient(gomock.NewController(t))
 	mockVTEX.EXPECT().AddOrUpdateCartItem(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	app := NewApp(NewPool(), rdb, nil, nil, nil, cm, nil, "", nil, mockVTEX)
 


### PR DESCRIPTION
## Summary

- After a successful cart item add/update, POST `{"utmSource": "weni-concierge"}` to the order form's `marketingData` attachment
- The UTM update runs sequentially after `cart_updated` is sent to the client, so it never delays the user-facing response
- Failures are logged at warn level and do not affect the cart operation result

## Test plan

- [x] `TestUpdateMarketingData_Success` — correct URL, method, and body
- [x] `TestUpdateMarketingData_Error` — error returned on non-200
- [x] `TestUpdateMarketingData_InvalidInputs` — validation rejects bad inputs
- [x] `TestAddToCart_HappyPath` — updated to expect UTM call
- [x] `TestAddToCart_MarketingDataFailureDoesNotAffectCart` — cart_updated still sent when UTM fails
- [x] `TestAddToCart_VTEXError` — UTM not called when cart fails

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new outbound VTEX Checkout API call on every successful `add_to_cart`, which could introduce extra latency/load and new failure modes (though errors are downgraded to warnings and don’t impact the client response).
> 
> **Overview**
> After a successful cart item add/update, the websocket `add_to_cart` flow now also updates the VTEX order form’s marketing data by POSTing `{"utmSource":"weni-concierge"}` to `/attachments/marketingData`.
> 
> This introduces a new `VTEXClient.UpdateMarketingData` method (with input validation and gomock support) and adds unit tests covering success, error, and invalid-input cases, plus websocket tests ensuring UTM update failures don’t prevent `cart_updated` from being sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 202ee6f295e41f6a9ed8282fb18c12f7308bd6c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->