### PR TITLE
feat: enhance UpdateMarketingData to include utmSource parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v3.11.0
+----------
+* feat: enhance UpdateMarketingData to include utmSource parameter
+
 v3.10.0
 ----------
 * feat: add connection_attempts metric labeled by origin and status, with Referer fallback and <none>/<opaque> label sentinels when Origin is missing

--- a/pkg/vtex/client.go
+++ b/pkg/vtex/client.go
@@ -18,7 +18,7 @@ var safeSlugRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*$`)
 // IClient abstracts VTEX cart operations for testability.
 type IClient interface {
 	AddOrUpdateCartItem(ctx context.Context, vtexAccount, orderFormID, itemID, seller string) error
-	UpdateMarketingData(ctx context.Context, vtexAccount, orderFormID string) error
+	UpdateMarketingData(ctx context.Context, vtexAccount, orderFormID, utmSource string) error
 }
 
 // OrderFormItem represents a single item in the VTEX order form.
@@ -191,7 +191,7 @@ func (c *Client) AddOrUpdateCartItem(ctx context.Context, vtexAccount, orderForm
 }
 
 // UpdateMarketingData sets utmSource on the order form's marketing data attachment.
-func (c *Client) UpdateMarketingData(ctx context.Context, vtexAccount, orderFormID string) error {
+func (c *Client) UpdateMarketingData(ctx context.Context, vtexAccount, orderFormID, utmSource string) error {
 	if !safeSlugRe.MatchString(vtexAccount) {
 		return fmt.Errorf("vtex: invalid account name %q", vtexAccount)
 	}
@@ -200,6 +200,6 @@ func (c *Client) UpdateMarketingData(ctx context.Context, vtexAccount, orderForm
 	}
 
 	reqURL := c.orderFormURL(vtexAccount, orderFormID) + "/attachments/marketingData"
-	body := marketingDataRequest{UTMSource: "weni-concierge"}
+	body := marketingDataRequest{UTMSource: utmSource}
 	return c.postJSON(ctx, reqURL, body)
 }

--- a/pkg/vtex/client_mock.go
+++ b/pkg/vtex/client_mock.go
@@ -46,15 +46,15 @@ func (mr *MockIClientMockRecorder) AddOrUpdateCartItem(ctx, vtexAccount, orderFo
 }
 
 // UpdateMarketingData mocks base method.
-func (m *MockIClient) UpdateMarketingData(ctx context.Context, vtexAccount, orderFormID string) error {
+func (m *MockIClient) UpdateMarketingData(ctx context.Context, vtexAccount, orderFormID, utmSource string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateMarketingData", ctx, vtexAccount, orderFormID)
+	ret := m.ctrl.Call(m, "UpdateMarketingData", ctx, vtexAccount, orderFormID, utmSource)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateMarketingData indicates an expected call of UpdateMarketingData.
-func (mr *MockIClientMockRecorder) UpdateMarketingData(ctx, vtexAccount, orderFormID interface{}) *gomock.Call {
+func (mr *MockIClientMockRecorder) UpdateMarketingData(ctx, vtexAccount, orderFormID, utmSource interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMarketingData", reflect.TypeOf((*MockIClient)(nil).UpdateMarketingData), ctx, vtexAccount, orderFormID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMarketingData", reflect.TypeOf((*MockIClient)(nil).UpdateMarketingData), ctx, vtexAccount, orderFormID, utmSource)
 }

--- a/pkg/vtex/client_test.go
+++ b/pkg/vtex/client_test.go
@@ -191,12 +191,12 @@ func TestUpdateMarketingData_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server)
-	err := client.UpdateMarketingData(context.Background(), "teststore", "of123")
+	err := client.UpdateMarketingData(context.Background(), "teststore", "of123", "cx_shopping_assistant_cart")
 
 	assert.NoError(t, err)
 	assert.Equal(t, http.MethodPost, receivedMethod)
 	assert.Equal(t, "/api/checkout/pub/orderForm/of123/attachments/marketingData", receivedPath)
-	assert.Equal(t, "weni-concierge", receivedBody.UTMSource)
+	assert.Equal(t, "cx_shopping_assistant_cart", receivedBody.UTMSource)
 }
 
 func TestUpdateMarketingData_Error(t *testing.T) {
@@ -207,7 +207,7 @@ func TestUpdateMarketingData_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server)
-	err := client.UpdateMarketingData(context.Background(), "teststore", "of123")
+	err := client.UpdateMarketingData(context.Background(), "teststore", "of123", "cx_shopping_assistant_cart")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cart operation failed with status 500")
@@ -230,7 +230,7 @@ func TestUpdateMarketingData_InvalidInputs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := c.UpdateMarketingData(context.Background(), tt.account, tt.orderFormID)
+			err := c.UpdateMarketingData(context.Background(), tt.account, tt.orderFormID, "cx_shopping_assistant_cart")
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errContains)
 		})

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -80,6 +80,9 @@ type Client struct {
 	AuthToken          string
 	Histories          history.Service
 	mu                 sync.Mutex
+	interactionUTMSent bool
+	vtexAccount        string
+	orderFormID        string
 }
 
 func (c *Client) ChannelUUID() string {
@@ -274,6 +277,13 @@ func (c *Client) SetCustomField(payload OutgoingPayload, app *App) error {
 		return errors.Wrap(err, "set custom field")
 	}
 
+	switch key {
+	case "vtex_account":
+		c.vtexAccount = value
+	case "orderform":
+		c.orderFormID = value
+	}
+
 	return nil
 }
 
@@ -382,6 +392,20 @@ func (c *Client) GetPDPStarters(payload OutgoingPayload, app *App) error {
 					"client_id": c.ID,
 					"channel":   c.Channel,
 				}).WithError(sendErr).Error("failed to send starters payload to client")
+			}
+		}
+
+		if c.orderFormID != "" && app.VTEXClient != nil {
+			utmCtx, utmCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer utmCancel()
+
+			if utmErr := app.VTEXClient.UpdateMarketingData(utmCtx, account, c.orderFormID, "cx_shopping_assistant_conv_stater"); utmErr != nil {
+				log.WithFields(log.Fields{
+					"client_id":     c.ID,
+					"channel":       c.Channel,
+					"vtex_account":  account,
+					"order_form_id": c.orderFormID,
+				}).WithError(utmErr).Warn("failed to update VTEX marketing data for starters")
 			}
 		}
 	}()
@@ -795,6 +819,16 @@ func (c *Client) Redirect(payload OutgoingPayload, to postJSON, app *App) error 
 
 	payload.From = c.ID
 	payload.Callback = c.Callback
+
+	if payload.Type == "message_with_fields" && payload.Data != nil {
+		if v, ok := payload.Data["vtex_account"].(string); ok && v != "" {
+			c.vtexAccount = v
+		}
+		if v, ok := payload.Data["orderform"].(string); ok && v != "" {
+			c.orderFormID = v
+		}
+	}
+
 	presenter, err := formatOutgoingPayload(payload)
 	if err != nil {
 		return err
@@ -871,6 +905,27 @@ func (c *Client) Redirect(payload OutgoingPayload, to postJSON, app *App) error 
 				}).WithError(err).Error("failed to save outgoing message to history")
 				return err
 			}
+		}
+	}
+
+	if !c.interactionUTMSent && (payload.Type == "message" || payload.Type == "message_with_fields") {
+		if c.vtexAccount != "" && c.orderFormID != "" && app.VTEXClient != nil {
+			c.interactionUTMSent = true
+			vtexAccount := c.vtexAccount
+			orderFormID := c.orderFormID
+			go func() {
+				utmCtx, utmCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer utmCancel()
+
+				if utmErr := app.VTEXClient.UpdateMarketingData(utmCtx, vtexAccount, orderFormID, "cx_shopping_assistant"); utmErr != nil {
+					log.WithFields(log.Fields{
+						"client_id":     c.ID,
+						"channel":       c.Channel,
+						"vtex_account":  vtexAccount,
+						"order_form_id": orderFormID,
+					}).WithError(utmErr).Warn("failed to update VTEX marketing data for interaction")
+				}
+			}()
 		}
 	}
 
@@ -1063,7 +1118,7 @@ func (c *Client) AddToCart(payload OutgoingPayload, app *App) error {
 		utmCtx, utmCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer utmCancel()
 
-		if utmErr := app.VTEXClient.UpdateMarketingData(utmCtx, vtexAccount, orderFormID); utmErr != nil {
+		if utmErr := app.VTEXClient.UpdateMarketingData(utmCtx, vtexAccount, orderFormID, "cx_shopping_assistant_cart"); utmErr != nil {
 			log.WithFields(log.Fields{
 				"client_id":     c.ID,
 				"channel":       c.Channel,

--- a/pkg/websocket/client_test.go
+++ b/pkg/websocket/client_test.go
@@ -1781,7 +1781,7 @@ func TestAddToCart_HappyPath(t *testing.T) {
 
 	mockVTEX := vtex.NewMockIClient(ctrl)
 	mockVTEX.EXPECT().AddOrUpdateCartItem(gomock.Any(), "teststore", "of123", "prod_1", "seller_a").Return(nil)
-	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), "teststore", "of123").Return(nil)
+	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), "teststore", "of123", "cx_shopping_assistant_cart").Return(nil)
 
 	client, ws, server := newTestClient(t)
 	defer server.Close()
@@ -1965,7 +1965,7 @@ func TestAddToCart_MarketingDataFailureDoesNotAffectCart(t *testing.T) {
 
 	mockVTEX := vtex.NewMockIClient(ctrl)
 	mockVTEX.EXPECT().AddOrUpdateCartItem(gomock.Any(), "teststore", "of123", "prod_1", "seller_a").Return(nil)
-	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), "teststore", "of123").
+	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), "teststore", "of123", "cx_shopping_assistant_cart").
 		Return(fmt.Errorf("vtex: cart operation failed with status 500"))
 
 	client, ws, server := newTestClient(t)
@@ -2005,7 +2005,7 @@ func TestAddToCartParsePayload(t *testing.T) {
 
 	mockVTEX := vtex.NewMockIClient(gomock.NewController(t))
 	mockVTEX.EXPECT().AddOrUpdateCartItem(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), gomock.Any(), gomock.Any(), "cx_shopping_assistant_cart").Return(nil)
 
 	app := NewApp(NewPool(), rdb, nil, nil, nil, cm, nil, "", nil, mockVTEX)
 
@@ -2031,4 +2031,305 @@ func TestAddToCartParsePayload(t *testing.T) {
 		},
 	}, toTest)
 	assert.NoError(t, err)
+}
+
+// --- UTM Tracking Tests ---
+
+func TestSetCustomField_CapturesVTEXFields(t *testing.T) {
+	rdb := redis.NewClient(&redis.Options{Addr: redisHost, DB: 3})
+	defer rdb.FlushAll(context.TODO())
+	cm := NewClientManager(rdb, 4)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	flowsClient := flows.NewClient(server.URL, nil)
+	app := NewApp(NewPool(), rdb, nil, nil, nil, cm, nil, "", flowsClient, nil)
+
+	client := &Client{
+		ID:       "wwc:1234567890",
+		Callback: "https://flows.example.com/c/wwc/09bf3dee-973e-43d3-8b94-441406c4a565/receive",
+	}
+
+	err := client.SetCustomField(OutgoingPayload{
+		Type: "set_custom_field",
+		Data: map[string]interface{}{
+			"key":   "vtex_account",
+			"value": "teststore",
+		},
+	}, app)
+	assert.NoError(t, err)
+	assert.Equal(t, "teststore", client.vtexAccount)
+
+	err = client.SetCustomField(OutgoingPayload{
+		Type: "set_custom_field",
+		Data: map[string]interface{}{
+			"key":   "orderform",
+			"value": "of123",
+		},
+	}, app)
+	assert.NoError(t, err)
+	assert.Equal(t, "of123", client.orderFormID)
+}
+
+func TestSetCustomField_IgnoresUnrelatedKeys(t *testing.T) {
+	rdb := redis.NewClient(&redis.Options{Addr: redisHost, DB: 3})
+	defer rdb.FlushAll(context.TODO())
+	cm := NewClientManager(rdb, 4)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	flowsClient := flows.NewClient(server.URL, nil)
+	app := NewApp(NewPool(), rdb, nil, nil, nil, cm, nil, "", flowsClient, nil)
+
+	client := &Client{
+		ID:       "wwc:1234567890",
+		Callback: "https://flows.example.com/c/wwc/09bf3dee-973e-43d3-8b94-441406c4a565/receive",
+	}
+
+	err := client.SetCustomField(OutgoingPayload{
+		Type: "set_custom_field",
+		Data: map[string]interface{}{
+			"key":   "some_other_field",
+			"value": "whatever",
+		},
+	}, app)
+	assert.NoError(t, err)
+	assert.Empty(t, client.vtexAccount)
+	assert.Empty(t, client.orderFormID)
+}
+
+func TestMessageWithFields_CapturesVTEXData(t *testing.T) {
+	client, ws, server := newTestClient(t)
+	defer server.Close()
+	defer ws.Close()
+	client.ID = "test-client"
+	client.Callback = "http://example.com/callback"
+
+	app := &App{}
+
+	toTest := func(url string, data interface{}) ([]byte, error) {
+		return nil, nil
+	}
+
+	err := client.Redirect(OutgoingPayload{
+		Type: "message_with_fields",
+		From: client.ID,
+		Message: Message{
+			Type: "text",
+			Text: "hello",
+		},
+		Data: map[string]interface{}{
+			"vtex_account": "teststore",
+			"orderform":    "of456",
+		},
+	}, toTest, app)
+	assert.NoError(t, err)
+	assert.Equal(t, "teststore", client.vtexAccount)
+	assert.Equal(t, "of456", client.orderFormID)
+}
+
+func TestMessageWithFields_DoesNotCaptureOnRegularMessage(t *testing.T) {
+	client, ws, server := newTestClient(t)
+	defer server.Close()
+	defer ws.Close()
+	client.ID = "test-client"
+	client.Callback = "http://example.com/callback"
+
+	app := &App{}
+
+	toTest := func(url string, data interface{}) ([]byte, error) {
+		return nil, nil
+	}
+
+	err := client.Redirect(OutgoingPayload{
+		Type: "message",
+		From: client.ID,
+		Message: Message{
+			Type: "text",
+			Text: "hello",
+		},
+		Data: map[string]interface{}{
+			"vtex_account": "teststore",
+			"orderform":    "of456",
+		},
+	}, toTest, app)
+	assert.NoError(t, err)
+	assert.Empty(t, client.vtexAccount)
+	assert.Empty(t, client.orderFormID)
+}
+
+func TestInteractionUTM_FiresOnFirstMessage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockVTEX := vtex.NewMockIClient(ctrl)
+	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), "teststore", "of123", "cx_shopping_assistant").Return(nil)
+
+	client, ws, server := newTestClient(t)
+	defer server.Close()
+	defer ws.Close()
+	client.ID = "test-client"
+	client.Callback = "http://example.com/callback"
+	client.vtexAccount = "teststore"
+	client.orderFormID = "of123"
+
+	app := &App{VTEXClient: mockVTEX}
+
+	toTest := func(url string, data interface{}) ([]byte, error) {
+		return nil, nil
+	}
+
+	err := client.Redirect(OutgoingPayload{
+		Type: "message",
+		From: client.ID,
+		Message: Message{
+			Type: "text",
+			Text: "hello",
+		},
+	}, toTest, app)
+	assert.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+
+	assert.True(t, client.interactionUTMSent)
+}
+
+func TestInteractionUTM_DoesNotFireTwice(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockVTEX := vtex.NewMockIClient(ctrl)
+	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), "teststore", "of123", "cx_shopping_assistant").Return(nil).Times(1)
+
+	client, ws, server := newTestClient(t)
+	defer server.Close()
+	defer ws.Close()
+	client.ID = "test-client"
+	client.Callback = "http://example.com/callback"
+	client.vtexAccount = "teststore"
+	client.orderFormID = "of123"
+
+	app := &App{VTEXClient: mockVTEX}
+
+	toTest := func(url string, data interface{}) ([]byte, error) {
+		return nil, nil
+	}
+
+	for i := 0; i < 3; i++ {
+		err := client.Redirect(OutgoingPayload{
+			Type: "message",
+			From: client.ID,
+			Message: Message{
+				Type: "text",
+				Text: fmt.Sprintf("msg %d", i),
+			},
+		}, toTest, app)
+		assert.NoError(t, err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+}
+
+func TestInteractionUTM_SkipsWhenVTEXFieldsMissing(t *testing.T) {
+	client, ws, server := newTestClient(t)
+	defer server.Close()
+	defer ws.Close()
+	client.ID = "test-client"
+	client.Callback = "http://example.com/callback"
+
+	app := &App{}
+
+	toTest := func(url string, data interface{}) ([]byte, error) {
+		return nil, nil
+	}
+
+	err := client.Redirect(OutgoingPayload{
+		Type: "message",
+		From: client.ID,
+		Message: Message{
+			Type: "text",
+			Text: "hello",
+		},
+	}, toTest, app)
+	assert.NoError(t, err)
+	assert.False(t, client.interactionUTMSent)
+}
+
+func TestStartersUTM_FiresWhenOrderFormIDStored(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSvc := starters.NewMockStartersService(ctrl)
+	mockSvc.EXPECT().GetStarters(gomock.Any(), gomock.Any()).Return(
+		&starters.StartersOutput{Questions: []string{"Q1?"}}, nil,
+	)
+
+	mockVTEX := vtex.NewMockIClient(ctrl)
+	mockVTEX.EXPECT().UpdateMarketingData(gomock.Any(), "test-store", "of789", "cx_shopping_assistant_conv_stater").Return(nil)
+
+	client, ws, server := newTestClient(t)
+	defer server.Close()
+	defer ws.Close()
+	client.ID = "test-client"
+	client.Callback = "http://example.com/callback"
+	client.orderFormID = "of789"
+
+	app := startersApp(t, mockSvc, 10)
+	app.VTEXClient = mockVTEX
+
+	err := client.GetPDPStarters(OutgoingPayload{
+		Data: map[string]interface{}{
+			"account":  "test-store",
+			"linkText": "test-product",
+		},
+	}, app)
+	assert.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+
+	ws.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var received IncomingPayload
+	err = ws.ReadJSON(&received)
+	assert.NoError(t, err)
+	assert.Equal(t, "starters", received.Type)
+}
+
+func TestStartersUTM_SkipsWhenOrderFormIDMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSvc := starters.NewMockStartersService(ctrl)
+	mockSvc.EXPECT().GetStarters(gomock.Any(), gomock.Any()).Return(
+		&starters.StartersOutput{Questions: []string{"Q1?"}}, nil,
+	)
+
+	client, ws, server := newTestClient(t)
+	defer server.Close()
+	defer ws.Close()
+	client.ID = "test-client"
+	client.Callback = "http://example.com/callback"
+
+	app := startersApp(t, mockSvc, 10)
+
+	err := client.GetPDPStarters(OutgoingPayload{
+		Data: map[string]interface{}{
+			"account":  "test-store",
+			"linkText": "test-product",
+		},
+	}, app)
+	assert.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+
+	ws.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var received IncomingPayload
+	err = ws.ReadJSON(&received)
+	assert.NoError(t, err)
+	assert.Equal(t, "starters", received.Type)
 }


### PR DESCRIPTION
Updated the UpdateMarketingData method across the VTEX client and its mocks to accept an additional utmSource parameter. Adjusted related tests to ensure proper functionality with the new parameter, ensuring that UTM tracking is accurately captured during marketing data updates.